### PR TITLE
MODELIX-177: Release MPS based components from own repository (2021.2 -> 2021.3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Exit if not on MPS branch (mps/202**)
-        if: startsWith(github.ref, 'refs/heads/mps/202') == false
-        run: exit -1
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -39,7 +35,7 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}}
+        run: ./gradlew assemble #publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,7 @@ jobs:
         run: echo "${GITHUB_REF#refs/*/}" > modelix.version
 
       - name: Build and Publish Maven
-        env:
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}}
+        run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}} -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/publishManual.yml
+++ b/.github/workflows/publishManual.yml
@@ -1,14 +1,11 @@
-name: Publish
+name: Publish Manual
 run-name: Publish ${{ inputs.MPS_VERSION }}.${{ inputs.TAG_NUMBER }}
 
 on:
   workflow_dispatch:
     inputs:
-        MPS_VERSION:
-          description: The MPS version (aka. prefix) of the TAG to release
-          required: true
-        TAG_NUMBER:
-          description: The patch version (aka. suffix) of the TAG to release
+        TAG_TO_RELEASE:
+          description: The TAG which should be released
           required: true
 
 jobs:
@@ -19,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "${{ inputs.MPS_VERSION }}.${{ inputs.TAG_NUMBER }}"
+          ref: "${{ inputs.TAG_TO_RELEASE }}"
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -28,7 +25,7 @@ jobs:
           java-version: '11'
 
       - name: Use tag name as version
-        run: echo "${GITHUB_REF#refs/*/}" > modelix.version
+        run: echo "${{ inputs.TAG_TO_RELEASE }}" > modelix.version
 
       - name: Build and Publish Maven
         env:

--- a/.github/workflows/publishManual.yml
+++ b/.github/workflows/publishManual.yml
@@ -1,5 +1,5 @@
 name: Publish Manual
-run-name: Publish ${{ inputs.MPS_VERSION }}.${{ inputs.TAG_NUMBER }}
+run-name: Publish ${{ inputs.TAG_TO_RELEASE }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publishManual.yml
+++ b/.github/workflows/publishManual.yml
@@ -1,14 +1,15 @@
 name: Publish
-run-name: Publish ${{ github.ref_name }}
+run-name: Publish ${{ inputs.MPS_VERSION }}.${{ inputs.TAG_NUMBER }}
 
 on:
-  # release on tagging
-  push:
-    tags:
-      - '2020.3.**'
-      - '2021.1.**'
-      - '2021.2.**'
-      - '2021.3.**'
+  workflow_dispatch:
+    inputs:
+        MPS_VERSION:
+          description: The MPS version (aka. prefix) of the TAG to release
+          required: true
+        TAG_NUMBER:
+          description: The patch version (aka. suffix) of the TAG to release
+          required: true
 
 jobs:
   newRelease:
@@ -17,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.MPS_VERSION }}.${{ inputs.TAG_NUMBER }}"
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -48,3 +51,4 @@ jobs:
           DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd docker && ./docker-build-projector.sh
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,25 +76,12 @@ subprojects {
             }
             maven {
                 name = "GitHubPackages"
-                // we moved this project modelix.mps from modelix/modelix but github packages
-                // cannot handle this situation. basically we suffer from what is described here:
-                //     https://github.com/orgs/community/discussions/23474
-                // this is a simple workaround for the affected components.
-                // consequently, when obtaining these dependencies, the repo url is the old modelix/modelix one...
-                if (project.name in arrayOf("mps")) {
-                    url = uri("https://maven.pkg.github.com/modelix/modelix")
-                    credentials {
-                        username = project.findProperty("gpr.user") as? String ?: System.getenv("GITHUB_ACTOR")
-                        password = project.findProperty("gpr.universalkey") as? String
-                                ?: System.getenv("GHP_UNIVERSAL_TOKEN")
-                    }
-                } else {
-                    url = uri("https://maven.pkg.github.com/modelix/modelix.mps")
-                    credentials {
-                        username = project.findProperty("gpr.user") as? String ?: System.getenv("GITHUB_ACTOR")
-                        password = project.findProperty("gpr.key") as? String ?: System.getenv("GITHUB_TOKEN")
-                    }
+                url = uri("https://maven.pkg.github.com/modelix/modelix.mps")
+                credentials {
+                    username = project.findProperty("gpr.user") as? String ?: System.getenv("GITHUB_ACTOR")
+                    password = project.findProperty("gpr.key") as? String ?: System.getenv("GITHUB_TOKEN")
                 }
+
             }
         }
     }


### PR DESCRIPTION
This is an automatic PR which merges changes from `mps/2021.2` to `mps/2021.3`

[Link to previous PR for `mps/2020.3`](https://github.com/modelix/modelix.mps/pull/49)