### PR TITLE
MODELIX-177: Release MPS based components from own repository #47  (2020.3 -> 2021.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,5 +42,4 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd docker && ./docker-build-projector.sh

--- a/.github/workflows/publishManual.yml
+++ b/.github/workflows/publishManual.yml
@@ -29,10 +29,7 @@ jobs:
 
       - name: Build and Publish Maven
         env:
-          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}}
+        run: ./gradlew assemble publish -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}} -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -46,6 +43,4 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd docker && ./docker-build-projector.sh
-

--- a/docker/docker-build-projector.sh
+++ b/docker/docker-build-projector.sh
@@ -11,6 +11,8 @@ cp -r ../build/org.modelix/build/artifacts/org.modelix build/artifacts/
 MPS_VERSION=$( ./helper/mps-version.sh )
 MODELIX_VERSION=$( ./helper/modelix-version.sh )
 
+docker login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_KEY"
+
 if [ "${CI}" = "true" ]; then
   docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg MPS_VERSION=${MPS_VERSION} -f Dockerfile-projector \
   -t "modelix/modelix-projector:${MODELIX_VERSION}" .


### PR DESCRIPTION
This is an automatic PR which merges changes from `mps/2020.3` to `mps/2021.1`.

[Link to previous PR for `mps/2020.3`](https://github.com/modelix/modelix.mps/pull/51)